### PR TITLE
Automated trunk upgrade trufflehog 3.89.2 → 3.90.0 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -25,7 +25,7 @@ lint:
     - markdownlint@0.45.0
     - shellcheck@0.10.0
     - shfmt@3.6.0
-    - trufflehog@3.89.2
+    - trufflehog@3.90.0
     - yamlfmt@0.17.2
     - yamllint@1.37.1
   disabled:


### PR DESCRIPTION

1 linter was upgraded:

- trufflehog 3.89.2 → 3.90.0

