### PR TITLE
Automated trunk upgrade cli upgraded 1.24.0 → 1.25.0, shellcheck 0.10.0 → 0.11.0, trufflehog 3.90.3 → 3.90.8, trunk-io/plugins v1.7.1 → v1.7.2 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,14 +2,14 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.24.0
+  version: 1.25.0
 repo:
   trunk_branch: updates
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.1
+      ref: v1.7.2
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -23,9 +23,9 @@ lint:
     - actionlint@1.7.7
     - git-diff-check
     - markdownlint@0.45.0
-    - shellcheck@0.10.0
+    - shellcheck@0.11.0
     - shfmt@3.6.0
-    - trufflehog@3.90.3
+    - trufflehog@3.90.8
     - yamlfmt@0.17.2
     - yamllint@1.37.1
   disabled:


### PR DESCRIPTION


cli upgraded: 1.24.0 → 1.25.0

2 linters were upgraded:

- shellcheck 0.10.0 → 0.11.0
- trufflehog 3.90.3 → 3.90.8

1 plugin was upgraded:

- trunk-io/plugins v1.7.1 → v1.7.2

