### PR TITLE
Automated trunk upgrade actionlint 1.7.8 → 1.7.9, markdownlint 0.45.0 → 0.46.0, trufflehog 3.91.0 → 3.91.2 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,12 +20,12 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - actionlint@1.7.8
+    - actionlint@1.7.9
     - git-diff-check
-    - markdownlint@0.45.0
+    - markdownlint@0.46.0
     - shellcheck@0.11.0
     - shfmt@3.6.0
-    - trufflehog@3.91.0
+    - trufflehog@3.91.2
     - yamlfmt@0.20.0
     - yamllint@1.37.1
   disabled:


### PR DESCRIPTION

3 linters were upgraded:

- actionlint 1.7.8 → 1.7.9
- markdownlint 0.45.0 → 0.46.0
- trufflehog 3.91.0 → 3.91.2

