### PR TITLE
Automated trunk upgrade markdownlint 0.46.0 → 0.47.0, trufflehog 3.91.2 → 3.92.3 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -22,10 +22,10 @@ lint:
   enabled:
     - actionlint@1.7.9
     - git-diff-check
-    - markdownlint@0.46.0
+    - markdownlint@0.47.0
     - shellcheck@0.11.0
     - shfmt@3.6.0
-    - trufflehog@3.91.2
+    - trufflehog@3.92.3
     - yamlfmt@0.20.0
     - yamllint@1.37.1
   disabled:


### PR DESCRIPTION

2 linters were upgraded:

- markdownlint 0.46.0 → 0.47.0
- trufflehog 3.91.2 → 3.92.3

