### PR TITLE
Automated trunk upgrade actionlint 1.7.9 → 1.7.10, yamlfmt 0.20.0 → 0.21.0 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,13 +20,13 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - actionlint@1.7.9
+    - actionlint@1.7.10
     - git-diff-check
     - markdownlint@0.47.0
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - trufflehog@3.92.4
-    - yamlfmt@0.20.0
+    - yamlfmt@0.21.0
     - yamllint@1.37.1
   disabled:
     - checkov


### PR DESCRIPTION

2 linters were upgraded:

- actionlint 1.7.9 → 1.7.10
- yamlfmt 0.20.0 → 0.21.0

