### PR TITLE
Automated trunk upgrade actionlint 1.7.10 → 1.7.12, markdownlint 0.47.0 → 0.48.0, trufflehog 3.93.3 → 3.95.2, trunk-io/plugins v1.7.4 → v1.8.0, python 3.11.9 → 3.14.4 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -9,23 +9,23 @@ repo:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.4
+      ref: v1.8.0
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
     - go@1.21.0
     - node@22.16.0
-    - python@3.11.9
+    - python@3.14.4
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - actionlint@1.7.10
+    - actionlint@1.7.12
     - git-diff-check
-    - markdownlint@0.47.0
+    - markdownlint@0.48.0
     - shellcheck@0.11.0
     - shfmt@3.6.0
-    - trufflehog@3.93.3
+    - trufflehog@3.95.2
     - yamlfmt@0.21.0
     - yamllint@1.38.0
   disabled:


### PR DESCRIPTION

3 linters were upgraded:

- actionlint 1.7.10 → 1.7.12
- markdownlint 0.47.0 → 0.48.0
- trufflehog 3.93.3 → 3.95.2

1 plugin was upgraded:

- trunk-io/plugins v1.7.4 → v1.8.0

1 runtime was upgraded:

- python 3.11.9 → 3.14.4

