### PR TITLE
Automated trunk upgrade markdownlint 0.48.0 → 0.49.0, trufflehog 3.95.2 → 3.95.6, trunk-io/plugins v1.8.0 → v1.10.2 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,7 +20,6 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - pinact@4.1.0
     - actionlint@1.7.12
     - git-diff-check
     - markdownlint@0.49.0
@@ -31,6 +30,7 @@ lint:
     - yamllint@1.38.0
   disabled:
     - checkov
+    - pinact
     - prettier
     - renovate
 actions:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -9,7 +9,7 @@ repo:
 plugins:
   sources:
     - id: trunk
-      ref: v1.8.0
+      ref: v1.10.2
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -20,12 +20,13 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
+    - pinact@4.1.0
     - actionlint@1.7.12
     - git-diff-check
-    - markdownlint@0.48.0
+    - markdownlint@0.49.0
     - shellcheck@0.11.0
     - shfmt@3.6.0
-    - trufflehog@3.95.2
+    - trufflehog@3.95.6
     - yamlfmt@0.21.0
     - yamllint@1.38.0
   disabled:


### PR DESCRIPTION

3 linters were upgraded:

- markdownlint 0.48.0 → 0.49.0
- trufflehog 3.95.2 → 3.95.6

1 plugin was upgraded:

- trunk-io/plugins v1.8.0 → v1.10.2

